### PR TITLE
[fork] add PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,18 @@
+
+   /!\ ATTENTION PLEASE /!\
+
+This is a fork of Tecsisa/foulkon. We intend to upstream all our changes.
+But first, we'd like to merge them into _our_ master branch, and consume them,
+to ensure that what we upstream is what we need.
+
+For you, dear PR author, this means: please pay attention to the "base fork"
+of your PR:
+
+--> If it's for our fork, it should say "chef/foulkon"
+
+    (When you select that, the screen will change and display "base: master")
+
+--> If you want to create an upstream pull request, it should say "Tecsisa/foulkon".
+
+
+-> Either way, please delete this text before submitting.


### PR DESCRIPTION
I, for one, have already opened a PR against the wrong repo when I was tired. _This_ should make that less likely. 😉 

Also, I propose we prepend commit messages with `[fork]`, if they're not intended for upstreaming. Like this one.