### PR TITLE
[fork] bootstrap resources from config data

### DIFF
--- a/habitat/default.toml
+++ b/habitat/default.toml
@@ -8,3 +8,47 @@ password = "foulkon"
 dbname = "foulkon"
 superuser_name = "automate"
 superuser_password = "pokemon"
+
+## example TOML for bootstrapping resources via hook[post-run]:
+## Note: see chef/a2's bootstrap/foulkon-worker.sh for acutal bootstrap data
+# [[users]]
+# externalId = "x-automate-authn"
+# path = "/services/"
+#
+# [[users]]
+# externalId = "admin"
+# path = "/users/mock/"
+#
+# [[organizations]]
+# name = "automate2"
+#
+#   [[organizations.groups]]
+#   name = "services"
+#   path = "/services/"
+#
+#   [[organizations.group_members]]
+#   group = "services"
+#   user = "x-automate-authn"
+#
+#   [[organizations.policies]]
+#   name = "admin_users"
+#   path = "/services/"
+#       [[organizations.policies.statements]]
+#       effect = "allow"
+#       actions = ["iam:CreateUser", "iam:GetUser", "iam:ListGroupsForUser"]
+#       resources = ["urn:iws:iam::user/*"]
+#
+#   [[organizations.group_policies]]
+#   group = "services"
+#   policy = "admin_users"
+#
+#   [[organizations.proxy_resources]]
+#   name = "example"
+#   path = "/example/"
+#
+#     [organizations.proxy_resources.resource]
+#     host = "http://traefik:81"
+#     path = "/resource"
+#     method = "GET"
+#     urn = "urn:examplews:application:v1:resource/get"
+#     action = "example:get"

--- a/habitat/hooks/post-run
+++ b/habitat/hooks/post-run
@@ -7,8 +7,24 @@ exec 2>&1
 exit 0
 {{~/if}}
 
-curl="curl -v -u admin:admin"
+curl="curl -u admin:admin"
 prefix=http://127.0.0.1:8000/api/v1
+
+create() {
+  request $prefix/$1 -d "$2"
+}
+
+link() {
+  request $prefix/$1 -XPOST
+}
+
+request() {
+  status=$($curl -s -o /dev/null -w "%{http_code}" "$@")
+  if [[ $status -ne 201 && $status -ne 204 && $status -ne 409 ]]; then
+    echo "unexpected response code: $status"
+    echo "in call request $@"
+  fi
+}
 
 # if this returns 401, we're ready
 until $(curl -s -o /dev/null -w "%{http_code}\n" $prefix | grep -q 401); do
@@ -16,10 +32,28 @@ until $(curl -s -o /dev/null -w "%{http_code}\n" $prefix | grep -q 401); do
     sleep 1
 done
 
-# super-simple initial bootstrap
-$curl $prefix/users -d '{"externalId": "x-automate-authn", "path": "/services/"}'
-$curl $prefix/organizations/automate/groups -d '{"name": "services", "path": "/services/"}'
-$curl $prefix/organizations/automate/groups/services/users/x-automate-authn -XPOST
-$curl $prefix/organizations/automate/policies -d '{"name": "admin_users", "path": "/services/", "statements": [{"effect":"allow", "actions":["iam:CreateUser", "iam:GetUser", "iam:ListGroupsForUser"], "resources":["urn:iws:iam::user/*"]}] }'
-$curl $prefix/organizations/automate/groups/services/policies/admin_users -X POST
+{{~#each cfg.users as |user|}}
+create users '{{toJson user}}'
+{{~/each}}
 
+{{~#each cfg.organizations as |org|}}
+  {{~#each org.groups as |group|}}
+create organizations/{{org.name}}/groups '{{toJson group}}'
+  {{~/each}}
+
+  {{~#each org.group_members as |group_member|}}
+link organizations/{{org.name}}/groups/{{group_member.group}}/users/{{group_member.user}}
+  {{~/each}}
+
+  {{~#each org.policies as |policy|}}
+create organizations/{{org.name}}/policies '{{toJson policy}}'
+  {{~/each}}
+
+  {{~#each org.group_policies as |group_policy|}}
+link organizations/{{org.name}}/groups/{{group_policy.group}}/policies/{{group_policy.policy}}
+  {{~/each}}
+
+  {{~#each org.proxy_resources as |proxy_resource|}}
+create organizations/{{org.name}}/proxy-resources '{{toJson proxy_resource}}'
+  {{~/each}}
+{{~/each}}


### PR DESCRIPTION
This habitat artifact can now create users, groups, policies, and proxy resources
itself, given the right habitat config. (Example included.)

⚠️  If configs are not injected, this will do nothing: the previously existing,
hardcoded minimal bootstrap was removed.